### PR TITLE
Admin merchant/user index (US 50/51)

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,0 +1,17 @@
+class Admin::MerchantsController < Admin::BaseController
+
+  def enable
+    @merchant = Merchant.find(params[:id])
+    @merchant.update(enabled: true)
+    redirect_to merchants_path
+  end
+
+  def disable
+    # binding.pry
+    @merchant = Merchant.find(params[:id])
+    @merchant.update(enabled: false)
+    # binding.pry
+    redirect_to merchants_path
+  end
+
+end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -7,11 +7,8 @@ class Admin::MerchantsController < Admin::BaseController
   end
 
   def disable
-    # binding.pry
     @merchant = Merchant.find(params[:id])
     @merchant.update(enabled: false)
-    # binding.pry
     redirect_to merchants_path
   end
-
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,11 @@
+class Admin::UsersController < Admin::BaseController
+
+  def index
+    @users = User.all
+  end
+  
+  def show
+    @user = User.find(params[:id])
+  end
+
+end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,9 @@
+<h1>All Users</h1>
+
+<% @users.each do |user| %>
+  <section id='user-<%= user.id %>'>
+    <h2><%= link_to user.name, "/admin/users/#{user.id}" %></h2>
+    <p><%= user.created_at %></p>
+    <p><%= user.role %></p>
+  </section>
+<% end %>

--- a/app/views/merchants/index.html.erb
+++ b/app/views/merchants/index.html.erb
@@ -2,5 +2,12 @@
 <% @merchants.each do |merchant| %>
   <section id='merchant-<%= merchant.id %>'>
     <h2><%= link_to merchant.name, "/merchants/#{merchant.id}" %></h2>
+    <h2><%= merchant.city %></h2>
+    <h2><%= merchant.state %></h2>
+    <% if current_admin? && merchant.enabled == false %>
+      <%= button_to 'Enable', admin_enable_url(merchant.id), method: :patch %>
+    <% else current_admin? && merchant.enabled == true %>
+      <%= button_to 'Disable', admin_disable_path(merchant.id), method: :put %>
+      <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,5 +44,7 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/users', to: "dashboard#all", as: 'all_users'
     get '/dashboard', to: 'dashboard#index', as: :dashboard
+    put '/merchants/:id', to: 'merchants#disable', as: :disable
+    patch '/merchants/:id', to: 'merchants#enable', as: :enable
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,9 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    get '/users', to: "dashboard#all", as: 'all_users'
+    # get '/users', to: "dashboard#all", as: 'all_users'
+    get '/users', to: "users#index", as: 'all_users'
+    get '/users/:id', to: "users#show"
     get '/dashboard', to: 'dashboard#index', as: :dashboard
     put '/merchants/:id', to: 'merchants#disable', as: :disable
     patch '/merchants/:id', to: 'merchants#enable', as: :enable

--- a/db/migrate/20190719223922_add_enabled_to_merchants.rb
+++ b/db/migrate/20190719223922_add_enabled_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddEnabledToMerchants < ActiveRecord::Migration[5.1]
+  def change
+    add_column :merchants, :enabled, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190715192930) do
+ActiveRecord::Schema.define(version: 20190719223922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(version: 20190715192930) do
     t.integer "zip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true
   end
 
   create_table "order_items", force: :cascade do |t|

--- a/spec/features/admin/admin_merchant_index_spec.rb
+++ b/spec/features/admin/admin_merchant_index_spec.rb
@@ -53,8 +53,6 @@ RSpec.describe "Admin Merchant Index Page" do
       click_button 'Login'
       visit '/merchants'
 
-      save_and_open_page
-
       expect(@brian.enabled).to eq(true)
 
       within "#merchant-#{@brian.id}" do

--- a/spec/features/admin/admin_merchant_index_spec.rb
+++ b/spec/features/admin/admin_merchant_index_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "Admin Merchant Index Page" do
+  describe "As an admin user" do
+    before :each do
+      @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, enabled: false)
+      @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @user_1 = User.create!(email: "1234@gmail.com", password: "password", name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 3)
+      @user_2 = User.create!(email: "12345@gmail.com", password: "password", name: "Parsley Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 3)
+    end
+
+    it "I see merchant's city and state next to their name" do
+
+
+      visit login_path
+
+      fill_in 'Email', with: @user_1.email
+      fill_in 'Password', with: @user_1.password
+      click_button 'Login'
+
+      visit '/merchants'
+      # save_and_open_page
+
+      expect(page).to have_content(@megan.city)
+      expect(page).to have_content(@megan.state)
+    end
+
+    it "I see a disable/enable button next to any merchants whose accts are enabled/disabled" do
+      visit login_path
+
+      fill_in 'Email', with: @user_1.email
+      fill_in 'Password', with: @user_1.password
+      click_button 'Login'
+
+      visit '/merchants'
+
+      expect(@megan.enabled).to eq(false)
+
+      within "#merchant-#{@megan.id}" do
+        expect(page).to have_button("Enable")
+        expect(page).to_not have_button("Disable")
+        click_button "Enable"
+      end
+      expect(current_path).to eq(merchants_path)
+      expect(@megan.reload.enabled).to eq(true)
+    end
+
+    it "I see a disable/enable button next to any merchants whose accts are enabled/disabled" do
+      visit login_path
+
+      fill_in 'Email', with: @user_2.email
+      fill_in 'Password', with: @user_2.password
+      click_button 'Login'
+      visit '/merchants'
+
+      save_and_open_page
+
+      expect(@brian.enabled).to eq(true)
+
+      within "#merchant-#{@brian.id}" do
+        expect(page).to have_button("Disable")
+        expect(page).to_not have_button("Enable")
+        click_button 'Disable'
+        # binding.pry
+      end
+      expect(current_path).to eq(merchants_path)
+      expect(@brian.reload.enabled).to eq(false)
+    end
+  end
+end

--- a/spec/features/admin/admin_user_index_spec.rb
+++ b/spec/features/admin/admin_user_index_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Admin User Index Page" do
+  describe "When I click the 'Users' link in the nav" do
+    before :each do
+      @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218, enabled: false)
+      @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+      @user_1 = User.create!(email: "1234@gmail.com", password: "password", name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 3)
+      @user_2 = User.create!(email: "12345@gmail.com", password: "password", name: "Parsley Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 2)
+    end
+
+    it "I see all users in the system" do
+      visit login_path
+
+      fill_in 'Email', with: @user_1.email
+      fill_in 'Password', with: @user_1.password
+      click_button 'Login'
+
+      click_link "All Users"
+      expect(page).to have_content(@user_1.name)
+      expect(page).to have_content(@user_2.name)
+
+      expect(page).to have_link(@user_1.name)
+      expect(page).to have_content(@user_1.created_at)
+      expect(page).to have_content(@user_1.role)
+
+      click_link(@user_1.name)
+      expect(current_path).to eq("/admin/users/#{@user_1.id}")
+
+      click_link "All Users"
+      expect(page).to have_link(@user_2.name)
+      expect(page).to have_content(@user_1.created_at)
+      expect(page).to have_content(@user_1.role)
+
+      click_link(@user_2.name)
+      expect(current_path).to eq("/admin/users/#{@user_2.id}")
+    end
+  end
+end


### PR DESCRIPTION
(US 50)
- Test to set up enable/disable buttons that should show up for merchants depending on whether they are enabled/disabled
- Migration that adds enabled column to merchants table w a default value of true
- non-RESTful routes for enable/disable actions
- Logic for enable/disable buttons
- Merchants Controller with enable/disable actions under Admin namespace

(US 51)
- Adds testing to make sure that an Admin who clicks All users should see all users/role/register date
- Updates routes to add admin/user index & show
- Adds admin/users index/show views
- Admin/Users controller w index/show methods
- Cleans up code