### PR TITLE
Add functionality for user cancelling an order

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,5 @@
 class Order < ApplicationRecord
+
   has_many :order_items
   has_many :items, through: :order_items
 
@@ -18,5 +19,13 @@ class Order < ApplicationRecord
 
   def total_quantity
     order_items.sum(:quantity)
+  end
+
+  def quantity_of_item(item)
+    order_items.where(item_id: item.id).sum(:quantity)
+  end
+
+  def pending?
+    status == "pending"
   end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -2,6 +2,8 @@ class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :item
 
+  enum status: ["unfulfilled", "fulfilled"]
+
   def subtotal
     quantity * price
   end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -16,3 +16,6 @@
 
 <p>Total Quantity of Items: <%= @order.total_quantity %></p>
 <h3>Grand Total: <%= number_to_currency(@order.grand_total) %></h3>
+<% if @pending %>
+  <%= button_to 'Cancel Order', update_profile_order_path(@order.id), method: :patch %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,11 +20,6 @@ Rails.application.routes.draw do
   patch '/cart/:change/:item_id', to: 'cart#update_quantity'
   delete '/cart/:item_id', to: 'cart#remove_item'
 
-
-  post '/profile/orders', to: 'orders#create', as: 'create_order'
-
-
-
   resources :users, only: [:new]
 
   get '/register', to: 'users#register'
@@ -36,6 +31,8 @@ Rails.application.routes.draw do
   patch 'profile/', to: 'users#update_password', as: 'update_password'
   get 'profile/orders', to: 'orders#index', as: 'profile_orders'
   get 'profile/order/:id', to: 'orders#show', as: 'profile_order'
+  post '/profile/orders', to: 'orders#create', as: 'create_order'
+  patch 'profile/order/:id', to: 'orders#update', as: 'update_profile_order'
 
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create', as: 'user_login'

--- a/db/migrate/20190702191840_create_order_items.rb
+++ b/db/migrate/20190702191840_create_order_items.rb
@@ -5,6 +5,7 @@ class CreateOrderItems < ActiveRecord::Migration[5.1]
       t.references :order, foreign_key: true
       t.float :price
       t.integer :quantity
+      t.integer :status, default: 0
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20190719223922) do
     t.bigint "order_id"
     t.float "price"
     t.integer "quantity"
+    t.integer "status", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_order_items_on_item_id"

--- a/spec/features/orders/cancel_spec.rb
+++ b/spec/features/orders/cancel_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered user' do
+  describe 'When I visit my Profile Orders page' do
+    describe "And I click on a link for order's show page" do
+      before(:each) do
+        @megan = Merchant.create!(name: 'Megans Marmalades', address: '123 Main St', city: 'Denver', state: 'CO', zip: 80218)
+        @brian = Merchant.create!(name: 'Brians Bagels', address: '125 Main St', city: 'Denver', state: 'CO', zip: 80218)
+        @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 10 )
+        @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 10 )
+        @user_1 = User.create!(email: "123@gmail.com", password: "password", name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+        @order_1 = @user_1.orders.create!(name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220)
+        @order_2 = @user_1.orders.create!(name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220)
+        @order_item_1 = @order_1.order_items.create!(item: @ogre, quantity: 2, price: @ogre.price)
+        @order_item_2 = @order_1.order_items.create!(item: @hippo, quantity: 4, price: @hippo.price)
+        @order_2.order_items.create!(item: @ogre, quantity: 5, price: @ogre.price)
+        @order_2.order_items.create!(item: @hippo, quantity: 2, price: @hippo.price)
+      end
+
+      describe "I see a button or link to cancel the order only if the order is still pending" do
+        it "When I click the cancel button for an order, the following happens:\n
+        - Each row in the order_items table is given a status of unfulfilled\n
+        - The order itself is given a status of cancelled\n
+        - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.\n
+        - I am returned to my profile page\n
+        - I see a flash message telling me the order is now cancelled\n
+        - And I see that this order now has an updated status of cancelled" do
+
+          visit profile_order_path(@order_1)
+          expect(page).to have_button('Cancel Order')
+
+          @order_1.update(status: 1)
+          visit profile_order_path(@order_1)
+          expect(page).to_not have_button('Cancel Order')
+
+          @order_1.update(status: 2)
+          visit profile_order_path(@order_1)
+          expect(page).to_not have_button('Cancel Order')
+
+          @order_1.update(status: 3)
+          visit profile_order_path(@order_1)
+          expect(page).to_not have_button('Cancel Order')
+
+          visit item_path(@ogre)
+          click_button 'Add to Cart'
+          visit item_path(@ogre)
+          click_button 'Add to Cart'
+          visit item_path(@hippo)
+          click_button 'Add to Cart'
+          visit item_path(@hippo)
+          click_button 'Add to Cart'
+          visit item_path(@hippo)
+          click_button 'Add to Cart'
+          visit item_path(@hippo)
+          click_button 'Add to Cart'
+
+          visit cart_path
+
+          click_button 'Check Out'
+
+          visit item_path(@ogre)
+          expect(page).to have_content("Inventory: 8")
+          visit item_path(@hippo)
+          expect(page).to have_content("Inventory: 6")
+
+          @order_1.update(status: 0)
+          visit profile_order_path(@order_1)
+
+          @order_item_1.update(status: 1)
+          @order_item_2.update(status: 1)
+
+          click_on 'Cancel Order'
+
+          expect(OrderItem.find(@order_item_1.id).status).to eq("unfulfilled")
+          expect(OrderItem.find(@order_item_2.id).status).to eq("unfulfilled")
+
+          expect(current_path).to eq(profile_path)
+          
+          expect(page).to have_content("Order ID: #{@order_1.id} has been cancelled.")
+
+          visit profile_order_path(@order_1)
+
+          expect(page).to have_content("Status: cancelled")
+
+          visit item_path(@ogre)
+          expect(page).to have_content("Inventory: 10")
+          visit item_path(@hippo)
+          expect(page).to have_content("Inventory: 10")
+        end
+      end
+    end
+  end
+end

--- a/spec/features/orders/show_spec.rb
+++ b/spec/features/orders/show_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe 'As a registered user' do
         @ogre = @megan.items.create!(name: 'Ogre', description: "I'm an Ogre!", price: 20, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 10 )
         @hippo = @brian.items.create!(name: 'Hippo', description: "I'm a Hippo!", price: 50, image: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTaLM_vbg2Rh-mZ-B4t-RSU9AmSfEEq_SN9xPP_qrA2I6Ftq_D9Qw', active: true, inventory: 10 )
         @user_1 = User.create!(email: "123@gmail.com", password: "password", name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220, role: 1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
         @order_1 = @user_1.orders.create!(name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220)
         @order_2 = @user_1.orders.create!(name: "PapRica Jones", address: "456 Main St.", city: "Denver", state: "CO", zip: 80220)
         @order_item_1 = @order_1.order_items.create!(item: @ogre, quantity: 2, price: @ogre.price)
         @order_item_2 = @order_1.order_items.create!(item: @hippo, quantity: 4, price: @hippo.price)
         @order_2.order_items.create!(item: @ogre, quantity: 5, price: @ogre.price)
-        @order_2.order_items.create!(item: @hippo, quantity: 6, price: @hippo.price)
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+        @order_2.order_items.create!(item: @hippo, quantity: 2, price: @hippo.price)
       end
 
       it "I see all information about the order, including the following information:\n


### PR DESCRIPTION
-Able to cancel order as a user
- Each row in the "order items" table is given a status of "unfulfilled"
- The order itself is given a status of "cancelled"
- Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
